### PR TITLE
Bump Messaging.Contracts to 1.0.8

### DIFF
--- a/shared/Messaging.Contracts/Events/Menu/Contracts.cs
+++ b/shared/Messaging.Contracts/Events/Menu/Contracts.cs
@@ -26,4 +26,32 @@ public record MenuItemUpdated
     bool IsAvailable,
     string RestaurantId,
     string LocationId
-); 
+);
+
+/// <summary>
+/// The full current modifier-group set for one menu item. Published whenever staff create,
+/// update, or delete a group (or its options) under that item - always the complete snapshot,
+/// never a delta, so a consumer never has to diff or worry about arrival order. An empty
+/// Groups list means the item's last group was just deleted.
+/// </summary>
+public record MenuItemModifiersChanged(
+    Guid MenuItemId,
+    string RestaurantId,
+    string LocationId,
+    IReadOnlyList<ModifierGroupSnapshot> Groups
+);
+
+public record ModifierGroupSnapshot(
+    Guid Id,
+    string Name,
+    string SelectionType,
+    bool Required,
+    IReadOnlyList<ModifierOptionSnapshot> Options
+);
+
+public record ModifierOptionSnapshot(
+    Guid Id,
+    string Name,
+    decimal PriceDelta,
+    bool IsDefault
+);

--- a/shared/Messaging.Contracts/Events/Payment/Contracts.cs
+++ b/shared/Messaging.Contracts/Events/Payment/Contracts.cs
@@ -1,10 +1,16 @@
 namespace Messaging.Contracts.Events.Payment;
 
+/// <param name="CustomerId">The diner this payment belongs to, or null for a staff-taken
+/// payment. This is the payment service's only source of ownership: it has no order data of
+/// its own, so without this it can only authorize on the payment.read scope - which every
+/// diner holds - and an order id is a bare GUID. Optional so the staff path, where nobody
+/// owns the payment, keeps publishing unchanged.</param>
 public record PaymentRequested(Guid CorrelationId, Guid OrderId,
-    Guid TableId, 
+    Guid TableId,
     long AmountCents,
     string RestaurantId,
-    string LocationId);
+    string LocationId,
+    Guid? CustomerId = null);
 public record PaymentSucceeded(Guid CorrelationId, Guid OrderId,
     string RestaurantId,
     string LocationId);

--- a/shared/Messaging.Contracts/Messaging.Contracts.csproj
+++ b/shared/Messaging.Contracts/Messaging.Contracts.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Messaging.Contracts</PackageId>
-  <Version>1.0.6</Version>
+  <Version>1.0.8</Version>
     <IsPackable>true</IsPackable>
     <Authors>basnets24</Authors>
     <RepositoryUrl>https://github.com/basnets24/restaurant.pos</RepositoryUrl>


### PR DESCRIPTION
## Summary
- `PaymentRequested.CustomerId` (optional) and `MenuItemModifiersChanged`/`ModifierGroupSnapshot`/`ModifierOptionSnapshot` — both already consumed on `diner-ordering` via a temporary `ProjectReference` pending this
- Version bump only, `shared/Messaging.Contracts/` exclusively — safe to merge alone, both additions are additive (optional param, new record types) so every existing publisher on `dev` compiles unchanged and nothing on `dev` consumes the new members yet

## Test plan
- [x] `dotnet build shared/Messaging.Contracts/Messaging.Contracts.csproj` clean
- [ ] After merge, confirm 1.0.8 is on the feed: `curl -u <user>:$GH_PAT https://nuget.pkg.github.com/basnets24/messaging.contracts/index.json` (version-index, not `dotnet package search` — that lags)
- [ ] Flip `order`/`payment`/`catalog` off their temporary `ProjectReference` back to `PackageReference Version="1.0.8"` on `diner-ordering`